### PR TITLE
Remove version <4 pinning of Sphinx

### DIFF
--- a/qiskit_optimization/algorithms/optimization_algorithm.py
+++ b/qiskit_optimization/algorithms/optimization_algorithm.py
@@ -41,19 +41,16 @@ class OptimizationResultStatus(Enum):
 
 @dataclass
 class SolutionSample:
-    """A sample of an optimization solution
-
-    Attributes:
-        x: the values of variables
-        fval: the objective function value
-        probability: the probability of this sample
-        status: the status of this sample
-    """
+    """A sample of an optimization solution."""
 
     x: np.ndarray
+    """The values of the variables"""
     fval: float
+    """The objective function value"""
     probability: float
+    """The probability of this sample"""
     status: OptimizationResultStatus
+    """The status of this sample"""
 
 
 class OptimizationResult:

--- a/qiskit_optimization/problems/__init__.py
+++ b/qiskit_optimization/problems/__init__.py
@@ -20,15 +20,10 @@ Quadratic program
 =================
 Structures for defining an optimization problem.
 
-.. autosummary::
-   :toctree: ../stubs/
-   :nosignatures:
-
-   QuadraticProgram
-
 Note:
     The following classes are not intended to be instantiated directly.
-    Objects of these types are available within an instantiated :class:`QuadraticProgram`.
+    Objects of these types are available within an instantiated
+    :class:`~qiskit_optimization.QuadraticProgram`.
 
 .. autosummary::
    :toctree: ../stubs/

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ pylatexenc>=1.4
 stestr>=2.0.0
 ddt>=1.2.0,!=1.4.0
 reno>=3.4.0
-Sphinx>=1.8.3,!=3.1.0,<4
+Sphinx>=1.8.3,!=3.1.0
 sphinx-panels
 sphinx-gallery
 sphinx-autodoc-typehints


### PR DESCRIPTION
CI was pinned earlier for Sphinx as there were various warnings emitted which are treated as errors by CI. We should be on the latest version of Sphinx like the other application repos for consistency etc. Any issues that arise when Sphinx went from 3 to 4 were already taken care of there - seems not here yet.

Anyway in running with the latest Sphinx it seems there were warnings over QuadraticProgram and SolutionSample. 

`QuadraticProgram` is documented and imported at the top level but also had an autosummary in the `problems` folder too which gave rise to a duplication. Since we prefer to import at top level I kept the documentation of it there and removed the autosummary from init file in problems. However I ensured that the first reference to QP links to the class so its still easily accessed from there.

`SolutionSample` duplication warnings were from it 4 attributes. It seems that the `Attributes:` tag in the docstring causes refs to be generated and classes have their attributes extracted automatically as well leading to duplication. So I removed attributes and relocated the text. It now looks like this 

![image](https://user-images.githubusercontent.com/40241007/138497074-b70b9ba4-eaea-4ed5-b8de-91d1cb3aebb9.png)

as compared to currently

![image](https://user-images.githubusercontent.com/40241007/138497221-ec057e3b-9798-43fb-b05f-1432417e2f29.png)

while the type is not right upfront now I think overall it looks neater - and the type does show up if you navigate into an attribute e.g.

![image](https://user-images.githubusercontent.com/40241007/138497522-d09cd782-1aea-4e40-9595-e6c3e113dc25.png)


