### PR TITLE
Remove Cplex 3.11 restriction now that Cplex supports it

### DIFF
--- a/releasenotes/notes/add-python311-support-b44aa96b718e7914.yaml
+++ b/releasenotes/notes/add-python311-support-b44aa96b718e7914.yaml
@@ -2,4 +2,3 @@
 upgrade:
   - |
     Added support for running with Python 3.11.
-    At the the time of the release, CPLEX didn't have a python 3.11 version.

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setuptools.setup(
     include_package_data=True,
     python_requires=">=3.7",
     extras_require={
-        "cplex": ["cplex;python_version < '3.11'"],
+        "cplex": ["cplex"],
         "cvx": ["cvxpy"],
         "matplotlib": ["matplotlib"],
         "gurobi": ["gurobipy"],


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

There was a new [Cplex release 22.1.1.1](https://pypi.org/project/cplex/22.1.1.1/#files) which added wheels for Python 3.11. This PR simply removes the version restriction from setup.py. Since the 3,11 support overall of Qiskit Optimization has not yet been released this did not need any reno, but I did update the reno from the 3.11 PR to remove the note above CPLEX not supporting 3.11.

### Details and comments


