### PR TITLE
Replace `SparsePauliOp.__eq__` with `equiv`

### DIFF
--- a/test/converters/test_converters.py
+++ b/test/converters/test_converters.py
@@ -400,7 +400,7 @@ class TestConverters(QiskitOptimizationTestCase):
         penalize = LinearEqualityToPenalty(penalty=1e5)
         op2 = penalize.convert(op)
         qubitop, offset = op2.to_ising(opflow=False)
-        self.assertEqual(qubitop, QUBIT_OP_MAXIMIZE_SAMPLE)
+        self.assertTrue(qubitop.equiv(QUBIT_OP_MAXIMIZE_SAMPLE))
         self.assertEqual(offset, OFFSET_MAXIMIZE_SAMPLE)
 
     def test_ising_to_quadraticprogram_linear(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix the following CI breakage.

```
==============================
Failed 1 tests - output below:
==============================

test.converters.test_converters.TestConverters.test_optimizationproblem_to_ising
--------------------------------------------------------------------------------

Captured traceback:
~~~~~~~~~~~~~~~~~~~
    Traceback (most recent call last):

      File "/home/runner/work/qiskit-optimization/qiskit-optimization/test/converters/test_converters.py", line 403, in test_optimizationproblem_to_ising
    self.assertEqual(qubitop, QUBIT_OP_MAXIMIZE_SAMPLE)

      File "/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/unittest/case.py", line 845, in assertEqual
    assertion_func(first, second, msg=msg)

      File "/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/unittest/case.py", line 838, in _baseAssertEqual
    raise self.failureException(msg)

    AssertionError: Spars[54 chars]Z', 'ZIIZ', 'IZZI', 'ZIZI', 'ZZII'],
         [159 chars]0.j]) != Spars[54 chars]Z', 'IZZI', 'ZIIZ', 'ZIZI', 'ZZII'],
         [159 chars]0.j])
```
https://github.com/qiskit-community/qiskit-optimization/actions/runs/5921004301/job/16052992672

### Details and comments


