### PR TITLE
Drop python 3.7 support

### DIFF
--- a/.github/workflows/deploy-code.yml
+++ b/.github/workflows/deploy-code.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,7 +116,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10', 3.11]
+        python-version: [3.8, 3.9, '3.10', 3.11]
         include:
           - os: macos-latest
             python-version: 3.8
@@ -222,7 +222,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8]
+        python-version: [3.8, '3.10']
     steps:
       - uses: actions/checkout@v3
         with:
@@ -309,10 +309,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - uses: actions/download-artifact@v3
         with:
-          name: ubuntu-latest-3.7
-          path: /tmp/o37
-      - uses: actions/download-artifact@v3
-        with:
           name: ubuntu-latest-3.8
           path: /tmp/o38
       - uses: actions/download-artifact@v3
@@ -348,7 +344,7 @@ jobs:
         shell: bash
       - name: Combined Deprecation Messages
         run: |
-          sort -f -u /tmp/o37/opt.dep /tmp/o38/opt.dep /tmp/o39/opt.dep /tmp/o310/opt.dep /tmp/o311/opt.dep /tmp/m38/opt.dep /tmp/m310/opt.dep /tmp/w38/opt.dep /tmp/w310/opt.dep || true
+          sort -f -u /tmp/o38/opt.dep /tmp/o39/opt.dep /tmp/o310/opt.dep /tmp/o311/opt.dep /tmp/m38/opt.dep /tmp/m310/opt.dep /tmp/w38/opt.dep /tmp/w310/opt.dep || true
         shell: bash
       - name: Coverage combine
         run: coverage3 combine /tmp/o38/opt.dat

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -222,7 +222,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8, '3.10']
+        python-version: [3.8, 3.11]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,4 +4,4 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 100
-target-version = ['py37', 'py38', 'py39', 'py310']
+target-version = ['py38', 'py39', 'py310', 'py311']

--- a/releasenotes/notes/drop_python_37-c640811d7c84520e.yaml
+++ b/releasenotes/notes/drop_python_37-c640811d7c84520e.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    Support for running with Python 3.7 has been removed.
+    To run Qiskit Optimization you need a minimum Python version of 3.8.
+

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,6 @@ setuptools.setup(
         "Operating System :: MacOS",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -72,7 +71,7 @@ setuptools.setup(
     packages=setuptools.find_packages(include=["qiskit_optimization", "qiskit_optimization.*"]),
     install_requires=REQUIREMENTS,
     include_package_data=True,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     extras_require={
         "cplex": ["cplex;python_version < '3.11'"],
         "cvx": ["cvxpy"],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.3.0
-envlist = py37, py38, py39, py310, py311, lint
+envlist = py38, py39, py310, py311, lint
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Qiskit has dropped support Python 3.7 and this follows suit for Qiskit Optimization.
follows https://github.com/qiskit-community/qiskit-finance/pull/288

depends on #536 

### Details and comments


