### PR TITLE
Fix a unit test error for Apple silicon

### DIFF
--- a/test/algorithms/test_admm.py
+++ b/test/algorithms/test_admm.py
@@ -211,7 +211,7 @@ class TestADMMOptimizer(QiskitOptimizationTestCase):
         self.assertIsNotNone(solution)
         self.assertIsInstance(solution, ADMMOptimizationResult)
         self.assertIsNotNone(solution.x)
-        np.testing.assert_almost_equal([0.0, 1.0, 0.0], solution.x, 3)
+        self.assertTrue(np.allclose(solution.x, [0, 1, 0]) or np.allclose(solution.x, [1, 0, 0]))
         self.assertIsNotNone(solution.fval)
         np.testing.assert_almost_equal(1.0, solution.fval, 3)
         self.assertIsNotNone(solution.state)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

A unit test error occurs for test_admm_ex5_warm_start because the optimal solution is not unique and some algorithms behave in a differently on Apple silicon maybe due to blas stuff.
The optimization problem is as follows.
```python
        v = mdl.binary_var(name="v")
        w = mdl.binary_var(name="w")
        t = mdl.binary_var(name="t")

        mdl.minimize(v + w + t)
        mdl.add_constraint(2 * v + 2 * w + t <= 3, "cons1")
        mdl.add_constraint(v + w + t >= 1, "cons2")
        mdl.add_constraint(v + w == 1, "cons3")
```
Due to symmetry of `v` and `w`, both `[0, 1, 0]` and `[1, 0, 0]` are optimal.

There are two options to fix this issue: 1) check two optimal solutions or 2) modify the problem to make `v` and `w` non-symmetry. This PR took the first option because the problem ex5 is cited from a paper.

Fixes #525


The result of test_admm.py on M1 is as follows.

this PR
```
..............
----------------------------------------------------------------------
Ran 14 tests in 6.516s

OK
```

main
```
.....F........
======================================================================
FAIL: test_admm_ex5_warm_start (test.algorithms.test_admm.TestADMMOptimizer)
Example 5 but with a warm start
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/ima/tasks/3_2023/qiskit/opt/test/algorithms/test_admm.py", line 214, in test_admm_ex5_warm_start
    np.testing.assert_almost_equal([0.0, 1.0, 0.0], solution.x, 3)
  File "/opt/homebrew/Cellar/python@3.10/3.10.13/Frameworks/Python.framework/Versions/3.10/lib/python3.10/contextlib.py", line 79, in inner
    return func(*args, **kwds)
  File "/Users/ima/envs/dev310/lib/python3.10/site-packages/numpy/testing/_private/utils.py", line 521, in assert_almost_equal
    return assert_array_almost_equal(actual, desired, decimal, err_msg)
  File "/opt/homebrew/Cellar/python@3.10/3.10.13/Frameworks/Python.framework/Versions/3.10/lib/python3.10/contextlib.py", line 79, in inner
    return func(*args, **kwds)
  File "/Users/ima/envs/dev310/lib/python3.10/site-packages/numpy/testing/_private/utils.py", line 1034, in assert_array_almost_equal
    assert_array_compare(compare, x, y, err_msg=err_msg, verbose=verbose,
  File "/opt/homebrew/Cellar/python@3.10/3.10.13/Frameworks/Python.framework/Versions/3.10/lib/python3.10/contextlib.py", line 79, in inner
    return func(*args, **kwds)
  File "/Users/ima/envs/dev310/lib/python3.10/site-packages/numpy/testing/_private/utils.py", line 797, in assert_array_compare
    raise AssertionError(msg)
AssertionError:
Arrays are not almost equal to 3 decimals

Mismatched elements: 2 / 3 (66.7%)
Max absolute difference: 1.
Max relative difference: 1.
 x: array([0., 1., 0.])
 y: array([1., 0., 0.])

----------------------------------------------------------------------
Ran 14 tests in 6.317s

FAILED (failures=1)
```

### Details and comments
