### PR TITLE
Fix a deprecation warning of matplotlib

### DIFF
--- a/qiskit_optimization/applications/bin_packing.py
+++ b/qiskit_optimization/applications/bin_packing.py
@@ -118,7 +118,7 @@ class BinPacking(OptimizationApplication):
         """
         import matplotlib.pyplot as plt
 
-        colors = plt.cm.get_cmap("jet", len(self._weights))
+        colors = plt.colormaps["jet"].resampled(len(self._weights))
         items_in_bins = self.interpret(result)
         num_bins = len(items_in_bins)
         fig, axes = plt.subplots()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes a deprecation warning.
https://github.com/qiskit-community/qiskit-optimization/pull/559#issuecomment-1726325288

> qiskit_optimization/applications/bin_packing.py:121: MatplotlibDeprecationWarning: The get_cmap function was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use ``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap(obj)`` instead.
  colors = plt.cm.get_cmap("jet", len(self._weights))


### Details and comments


