### PR TITLE
Improve documentation of INFINITY

### DIFF
--- a/qiskit_optimization/__init__.py
+++ b/qiskit_optimization/__init__.py
@@ -68,9 +68,7 @@ are that it cannot proceed to completion.
    :toctree: ../stubs/
    :nosignatures:
 
-    INFINITY
-
-A constant for infinity.
+    ~qiskit_optimization.infinity.INFINITY
 
 Submodules
 ==========

--- a/qiskit_optimization/infinity.py
+++ b/qiskit_optimization/infinity.py
@@ -14,3 +14,4 @@
 
 
 INFINITY = 1.0e20  # pylint: disable=invalid-name
+""" A constant for infinity. """


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #10 

It now comes out as

![image](https://github.com/qiskit-community/qiskit-optimization/assets/40241007/2ef81761-7f0c-4a82-a7f3-3a038858f85e)

with the linked page

![image](https://github.com/qiskit-community/qiskit-optimization/assets/40241007/4710a90c-6cf2-4312-9bf3-2393b96187a5)

It did try with autodata which brings what is in the separate page inline there on the main page. But then it has that yellow stripe across the page which changed things more. I know we have brought all methods onto the same page so maybe that is reasonable to do. But since it changed things more than simply fixing the text of what was there I left it with this more minimal change.

Either as it stands or with autodata it needs the fully qualified path to bring in the comment for the constant - otherwise you still get that `Convert a string or number to a floating point number, if possible.` which is what the docs currently show,


### Details and comments

I labelled it backport since we publish docs off stable and maybe we want to update/re-publish the docs with this fix.
