### PR TITLE
Add Python 3.12 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,7 +116,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8, 3.9, '3.10', 3.11]
+        python-version: [3.8, 3.9, '3.10', 3.11, 3.12]
         include:
           - os: macos-latest
             python-version: 3.8
@@ -325,6 +325,10 @@ jobs:
           path: /tmp/o311
       - uses: actions/download-artifact@v4
         with:
+          name: ubuntu-latest-3.12
+          path: /tmp/o312
+      - uses: actions/download-artifact@v4
+        with:
           name: macos-latest-3.8
           path: /tmp/m38
       - uses: actions/download-artifact@v4
@@ -344,7 +348,7 @@ jobs:
         shell: bash
       - name: Combined Deprecation Messages
         run: |
-          sort -f -u /tmp/o38/opt.dep /tmp/o39/opt.dep /tmp/o310/opt.dep /tmp/o311/opt.dep /tmp/m38/opt.dep /tmp/m311/opt.dep /tmp/w38/opt.dep /tmp/w311/opt.dep || true
+          sort -f -u /tmp/o38/opt.dep /tmp/o39/opt.dep /tmp/o310/opt.dep /tmp/o311/opt.dep /tmp/o312/opt.dep /tmp/m38/opt.dep /tmp/m311/opt.dep /tmp/w38/opt.dep /tmp/w311/opt.dep || true
         shell: bash
       - name: Coverage combine
         run: coverage3 combine /tmp/o38/opt.dat

--- a/releasenotes/notes/add-python312-support-e3e2bc0c6a10b613.yaml
+++ b/releasenotes/notes/add-python312-support-e3e2bc0c6a10b613.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Added support for using Qiskit Optimization with Python 3.12.
+

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Scientific/Engineering",
     ],
     keywords="qiskit sdk quantum optimization",
@@ -73,7 +74,7 @@ setuptools.setup(
     include_package_data=True,
     python_requires=">=3.8",
     extras_require={
-        "cplex": ["cplex; python_version < '3.12'"],
+        "cplex": ["cplex; python_version < '3.12' and platform_machine != 'arm64'"],
         "cvx": ["cvxpy"],
         "matplotlib": ["matplotlib"],
         "gurobi": ["gurobipy"],

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setuptools.setup(
     include_package_data=True,
     python_requires=">=3.8",
     extras_require={
-        "cplex": ["cplex"],
+        "cplex": ["cplex; python_version < '3.12'"],
         "cvx": ["cvxpy"],
         "matplotlib": ["matplotlib"],
         "gurobi": ["gurobipy"],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.3.0
-envlist = py38, py39, py310, py311, lint
+envlist = py38, py39, py310, py311, py312, lint
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #590

Add Python 3.12 support.
But since CPLEX does not support Python 3.12 (see [pypi](https://pypi.org/project/cplex/#files)), we need to add constraint to 'cplex' extra dependency.
Windows and mac are still tested with Python 3.11 because cplex are not available for 3.12.


Fixes #577 


### Details and comments

Latest cplex 22.1.1.1
![image](https://github.com/qiskit-community/qiskit-optimization/assets/31178928/017bcecd-34e1-4c25-88d8-67e9f62166a7)

