### PR TITLE
Update CPLEX-incompatible Python version in documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ To do this follow the instructions in the
 ### Optional Installs
 
 * **IBM CPLEX** may be installed using `pip install 'qiskit-optimization[cplex]'` to enable the reading of `LP` files and the usage of
-  the `CplexOptimizer`, wrapper for ``cplex.Cplex``. Currently there is no Python 3.12 version of CPLEX. In this case, the CPLEX install
-  command will have no effect.
+  the `CplexOptimizer`, wrapper for ``cplex.Cplex``. CPLEX is a separate package and its support of Python versions is independent of Qiskit Optimization, where this CPLEX command will have no effect if there is no compatible version of CPLEX available (yet).
 
 * **CVXPY** may be installed using the command `pip install 'qiskit-optimization[cvx]'`.
   CVXPY being installed will enable the usage of the Goemans-Williamson algorithm as an optimizer `GoemansWilliamsonOptimizer`.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To do this follow the instructions in the
 ### Optional Installs
 
 * **IBM CPLEX** may be installed using `pip install 'qiskit-optimization[cplex]'` to enable the reading of `LP` files and the usage of
-  the `CplexOptimizer`, wrapper for ``cplex.Cplex``. Currently there is no python 3.9 version of CPLEX. In this case, the CPLEX install
+  the `CplexOptimizer`, wrapper for ``cplex.Cplex``. Currently there is no Python 3.12 version of CPLEX. In this case, the CPLEX install
   command will have no effect.
 
 * **CVXPY** may be installed using the command `pip install 'qiskit-optimization[cvx]'`.

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -95,7 +95,7 @@ Optional installs
 =================
 
 * **IBM CPLEX** may be installed using ``pip install 'qiskit-optimization[cplex]'`` to enable the reading of `LP` files and the usage of
-  the `CplexOptimizer`, wrapper for ``cplex.Cplex``. Currently there is no python 3.9 version of CPLEX. In this case, the CPLEX install
+  the `CplexOptimizer`, wrapper for ``cplex.Cplex``. Currently there is no Python 3.12 version of CPLEX. In this case, the CPLEX install
   command will have no effect.
 
 * **CVXPY** may be installed using the command ``pip install 'qiskit-optimization[cvx]'``.

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -95,8 +95,7 @@ Optional installs
 =================
 
 * **IBM CPLEX** may be installed using ``pip install 'qiskit-optimization[cplex]'`` to enable the reading of `LP` files and the usage of
-  the `CplexOptimizer`, wrapper for ``cplex.Cplex``. Currently there is no Python 3.12 version of CPLEX. In this case, the CPLEX install
-  command will have no effect.
+  the `CplexOptimizer`, wrapper for ``cplex.Cplex``. CPLEX is a separate package and its support of Python versions is independent of Qiskit Optimization, where this CPLEX command will have no effect if there is no compatible version of CPLEX available (yet).
 
 * **CVXPY** may be installed using the command ``pip install 'qiskit-optimization[cvx]'``.
   CVXPY being installed will enable the usage of the Goemans-Williamson algorithm as an optimizer `GoemansWilliamsonOptimizer`.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Updates the version number of Python for which no CPLEX version exists, yet.
In this case, updating from 3.9 to 3.12.

This fixes issue #591.

### Details and comments

No more details required.
