### PR TITLE
Update intersphinx links and others

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A uniform interface as well as automatic conversion between different problem re
 allows users to solve problems using a large set of algorithms, from variational quantum algorithms,
 such as the Quantum Approximate Optimization Algorithm QAOA, to Grover Adaptive Search using the
 GroverOptimizer, leveraging fundamental algorithms provided by
-[Qiskit Algorithms](https://qiskit.org/ecosystem/algorithms/). Furthermore, the modular design
+[Qiskit Algorithms](https://qiskit-community.github.io/qiskit-algorithms/). Furthermore, the modular design
 of the optimization module allows it to be easily extended and facilitates rapid development and
 testing of new algorithms. Compatible classical optimizers are also provided for testing,
 validation, and benchmarking.
@@ -32,7 +32,7 @@ pip install qiskit-optimization
 If you want to work on the very latest work-in-progress versions, either to try features ahead of
 their official release or if you want to contribute to Optimization, then you can install from source.
 To do this follow the instructions in the
- [documentation](https://qiskit.org/ecosystem/optimization/getting_started.html#installation).
+ [documentation](https://qiskit-community.github.io/qiskit-optimization/getting_started.html#installation).
 
 
 ----------------------------------------------------------------------------------------------------
@@ -108,7 +108,7 @@ print(result.prettyprint())  # prints solution, x=[1, 0, 1, 0], the cost, fval=4
 ### Further examples
 
 Learning path notebooks may be found in the
-[optimization tutorials](https://qiskit.org/ecosystem/optimization/tutorials/index.html) section
+[optimization tutorials](https://qiskit-community.github.io/qiskit-optimization/tutorials/index.html) section
 of the documentation and are a great place to start.
 
 ----------------------------------------------------------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -183,8 +183,8 @@ intersphinx_mapping = {
     "scipy": ("https://docs.scipy.org/doc/scipy", None),
     "networkx": ("https://networkx.org/documentation/stable", None),
     "docplex.mp": ("https://ibmdecisionoptimization.github.io/docplex-doc/mp", None),
-    "qiskit": ("https://qiskit.org/documentation/", None),
-    "qiskit_algorithms": ("https://qiskit.org/ecosystem/algorithms", None),
+    "qiskit": ("https://docs.quantum.ibm.com/api/qiskit", None),
+    "qiskit_algorithms": ("https://qiskit-community.github.io/qiskit-algorithms", None),
 }
 
 html_context = {"analytics_enabled": True}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,7 +16,7 @@ A uniform interface as well as automatic conversion between different problem re
 allows users to solve problems using a large set of algorithms, from variational quantum algorithms,
 such as the Quantum Approximate Optimization Algorithm QAOA, to Grover Adaptive Search using the
 GroverOptimizer, leveraging fundamental algorithms provided by
-`Qiskit Algorithms <https://qiskit.org/ecosystem/algorithms/>`__. Furthermore, the modular design
+`Qiskit Algorithms <https://qiskit-community.github.io/qiskit-algorithms/>`__. Furthermore, the modular design
 of the optimization module allows it to be easily extended and facilitates rapid development and
 testing of new algorithms. Compatible classical optimizers are also provided for testing,
 validation, and benchmarking.

--- a/docs/migration/02_migration_guide_to_v0.6.rst
+++ b/docs/migration/02_migration_guide_to_v0.6.rst
@@ -16,7 +16,7 @@ Qiskit Optimization v0.6 supports only the new algorithms of Qiskit Algorithms.
 It is not the intention to provide detailed explanations of the
 new Qiskit Algorithms in this migration guide. We suggest that you read the
 `corresponding
-resources <https://qiskit.org/ecosystem/algorithms/index.html>`__
+resources <https://qiskit-community.github.io/qiskit-algorithms/index.html>`__
 of the Qiskit Algorithms documentation instead.
 
 We can basically use the existing codes by replacing ``qiskit.algorithms``

--- a/docs/tutorials/08_cvar_optimization.ipynb
+++ b/docs/tutorials/08_cvar_optimization.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "## Introduction\n",
     "\n",
-    "This notebook shows how to use the Conditional Value at Risk (CVaR) objective function introduced in [1] within the variational quantum optimization algorithms provided by [Qiskit Algorithms](https://qiskit.org/ecosystem/algorithms/). Particularly, it is shown how to setup the `MinimumEigenOptimizer` using `SamplingVQE` accordingly. \n",
+    "This notebook shows how to use the Conditional Value at Risk (CVaR) objective function introduced in [1] within the variational quantum optimization algorithms provided by [Qiskit Algorithms](https://qiskit-community.github.io/qiskit-algorithms/). Particularly, it is shown how to setup the `MinimumEigenOptimizer` using `SamplingVQE` accordingly. \n",
     "For a given set of shots with corresponding objective values of the considered optimization problem, the CVaR with confidence level $\\alpha \\in [0, 1]$ is defined as the average of the $\\alpha$ best shots.\n",
     "Thus, $\\alpha = 1$ corresponds to the standard expected value, while $\\alpha=0$ corresponds to the minimum of the given shots, and $\\alpha \\in (0, 1)$ is a tradeoff between focusing on better shots, but still applying some averaging to smoothen the optimization landscape.\n",
     "\n",

--- a/docs/tutorials/12_quantum_random_access_optimizer.ipynb
+++ b/docs/tutorials/12_quantum_random_access_optimizer.ipynb
@@ -303,7 +303,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The [MinimumEigensolverResult](https://qiskit.org/ecosystem/algorithms/stubs/qiskit_algorithms.MinimumEigensolverResult.html) that results from performing VQE on the relaxed Hamiltonian is available:"
+    "The [MinimumEigensolverResult](https://qiskit-community.github.io/qiskit-algorithms/stubs/qiskit_algorithms.MinimumEigensolverResult.html) that results from performing VQE on the relaxed Hamiltonian is available:"
    ]
   },
   {

--- a/qiskit_optimization/__init__.py
+++ b/qiskit_optimization/__init__.py
@@ -29,8 +29,9 @@ such as the Quantum Approximate Optimization Algorithm
 (:class:`~qiskit_algorithms.QAOA`), to
 `Grover Adaptive Search <https://arxiv.org/abs/quant-ph/9607014>`_
 (:class:`~algorithms.GroverOptimizer`), leveraging
-fundamental `minimum eigensolvers <https://qiskit-community.github.io/qiskit-algorithms/apidocs/
-qiskit_algorithms.html#minimum-eigensolvers>`_ provided by
+fundamental `minimum eigensolvers
+<https://qiskit-community.github.io/qiskit-algorithms/apidocs/qiskit_algorithms.html#minimum-eigensolvers>`_
+provided by
 `Qiskit Algorithms <https://qiskit-community.github.io/qiskit-algorithms/>`_.
 Furthermore, the modular design
 of the optimization module allows it to be easily extended and facilitates rapid development and

--- a/qiskit_optimization/__init__.py
+++ b/qiskit_optimization/__init__.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2023.
+# (C) Copyright IBM 2019, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -29,9 +29,9 @@ such as the Quantum Approximate Optimization Algorithm
 (:class:`~qiskit_algorithms.QAOA`), to
 `Grover Adaptive Search <https://arxiv.org/abs/quant-ph/9607014>`_
 (:class:`~algorithms.GroverOptimizer`), leveraging
-fundamental `minimum eigensolvers <https://qiskit.org/ecosystem/algorithms/apidocs/
+fundamental `minimum eigensolvers <https://qiskit-community.github.io/qiskit-algorithms/apidocs/
 qiskit_algorithms.html#minimum-eigensolvers>`_ provided by
-`Qiskit Algorithms <https://qiskit.org/ecosystem/algorithms/>`_.
+`Qiskit Algorithms <https://qiskit-community.github.io/qiskit-algorithms/>`_.
 Furthermore, the modular design
 of the optimization module allows it to be easily extended and facilitates rapid development and
 testing of new algorithms. Compatible classical optimizers are also provided for testing,

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -80,7 +80,7 @@ setuptools.setup(
     },
     project_urls={
         "Bug Tracker": "https://github.com/qiskit-community/qiskit-optimization/issues",
-        "Documentation": "https://qiskit.org/ecosystem/optimization/",
+        "Documentation": "https://qiskit-community.github.io/qiskit-optimization/",
         "Source Code": "https://github.com/qiskit-community/qiskit-optimization",
     },
     zip_safe=False,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Updates links away from qiskit.org to the new locations for the docs

Fixes #585
Fixes #586

### Details and comments

Now that all the applications and the algorithms docs are deployed on github pages this updates the intersphinx links, in conf.py, and also urls that are coded directly in other places such as the readme and tutorials. I did not alter past release notes. There is a redirect now in effect for the former location on `qiskit.org/ecosystem` so they get to the right place.

Note that the current theme is still emitting a link to qiskit.org/ecosystem, but that will get redirected for now until such time as Qiskit/qiskit_sphinx_theme#588 is resolved and new docs are generated with such an updated theme and re-deployed.
