### PR TITLE
Bump Mac and Win upper Python version for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,11 +121,11 @@ jobs:
           - os: macos-latest
             python-version: 3.8
           - os: macos-latest
-            python-version: '3.10'
+            python-version: 3.11
           - os: windows-latest
             python-version: 3.8
           - os: windows-latest
-            python-version: '3.10'
+            python-version: 3.11
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -329,22 +329,22 @@ jobs:
           path: /tmp/m38
       - uses: actions/download-artifact@v4
         with:
-          name: macos-latest-3.10
-          path: /tmp/m310
+          name: macos-latest-3.11
+          path: /tmp/m311
       - uses: actions/download-artifact@v4
         with:
           name: windows-latest-3.8
           path: /tmp/w38
       - uses: actions/download-artifact@v4
         with:
-          name: windows-latest-3.10
-          path: /tmp/w310
+          name: windows-latest-3.11
+          path: /tmp/w311
       - name: Install Dependencies
         run: pip install -U coverage coveralls diff-cover
         shell: bash
       - name: Combined Deprecation Messages
         run: |
-          sort -f -u /tmp/o38/opt.dep /tmp/o39/opt.dep /tmp/o310/opt.dep /tmp/o311/opt.dep /tmp/m38/opt.dep /tmp/m310/opt.dep /tmp/w38/opt.dep /tmp/w310/opt.dep || true
+          sort -f -u /tmp/o38/opt.dep /tmp/o39/opt.dep /tmp/o310/opt.dep /tmp/o311/opt.dep /tmp/m38/opt.dep /tmp/m311/opt.dep /tmp/w38/opt.dep /tmp/w311/opt.dep || true
         shell: bash
       - name: Coverage combine
         run: coverage3 combine /tmp/o38/opt.dat


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

I noticed, when looking at last nights CI, which had failed (was just due to some network issue where it timed out (re-running the job passed) that for Mac and Windows the job is still using Python 3.10. Normally we test these platforms at the lowest and highest Python level supported but perhaps this was kept at 3.10 as sometimes wheels for these, for the latest version of Python, are longer coming. (All other app repos are doing this at 3.8 and 3.11 so this change will bring Opt in to sync in that respect).

Anyway I updated these so Mac and Windows now test at 3.8 and 3.11, instead of 3.8 and 3.10. I would imagine this should all work by now, but can't check locally.

### Details and comments

Assuming this passes it will need the branch rules updated accordingly. I labelled it backport since the last release was not too long ago and this will keep CI in sync there too for any bug fixes etc.
