### PR TITLE
Fix tutorials to work with Qiskit 1.0

### DIFF
--- a/docs/tutorials/01_quadratic_program.ipynb
+++ b/docs/tutorials/01_quadratic_program.ipynb
@@ -825,7 +825,7 @@
     }
    ],
    "source": [
-    "import qiskit.tools.jupyter\n",
+    "import tutorial_magics\n",
     "\n",
     "%qiskit_version_table\n",
     "%qiskit_copyright"

--- a/docs/tutorials/02_converters_for_quadratic_programs.ipynb
+++ b/docs/tutorials/02_converters_for_quadratic_programs.ipynb
@@ -697,7 +697,7 @@
     }
    ],
    "source": [
-    "import qiskit.tools.jupyter\n",
+    "import tutorial_magics\n",
     "\n",
     "%qiskit_version_table\n",
     "%qiskit_copyright"

--- a/docs/tutorials/03_minimum_eigen_optimizer.ipynb
+++ b/docs/tutorials/03_minimum_eigen_optimizer.ipynb
@@ -644,7 +644,7 @@
     }
    ],
    "source": [
-    "import qiskit.tools.jupyter\n",
+    "import tutorial_magics\n",
     "\n",
     "%qiskit_version_table\n",
     "%qiskit_copyright"

--- a/docs/tutorials/04_grover_optimizer.ipynb
+++ b/docs/tutorials/04_grover_optimizer.ipynb
@@ -228,7 +228,7 @@
     }
    ],
    "source": [
-    "import qiskit.tools.jupyter\n",
+    "import tutorial_magics\n",
     "\n",
     "%qiskit_version_table\n",
     "%qiskit_copyright"

--- a/docs/tutorials/05_admm_optimizer.ipynb
+++ b/docs/tutorials/05_admm_optimizer.ipynb
@@ -447,7 +447,7 @@
     }
    ],
    "source": [
-    "import qiskit.tools.jupyter\n",
+    "import tutorial_magics\n",
     "\n",
     "%qiskit_version_table\n",
     "%qiskit_copyright"

--- a/docs/tutorials/06_examples_max_cut_and_tsp.ipynb
+++ b/docs/tutorials/06_examples_max_cut_and_tsp.ipynb
@@ -115,7 +115,6 @@
     "import numpy as np\n",
     "import networkx as nx\n",
     "\n",
-    "from qiskit.tools.visualization import plot_histogram\n",
     "from qiskit.circuit.library import TwoLocal\n",
     "from qiskit_optimization.applications import Maxcut, Tsp\n",
     "from qiskit_algorithms import SamplingVQE, NumPyMinimumEigensolver\n",
@@ -972,7 +971,7 @@
     }
    ],
    "source": [
-    "import qiskit.tools.jupyter\n",
+    "import tutorial_magics\n",
     "\n",
     "%qiskit_version_table\n",
     "%qiskit_copyright"
@@ -987,8 +986,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/07_examples_vehicle_routing.ipynb
+++ b/docs/tutorials/07_examples_vehicle_routing.ipynb
@@ -796,7 +796,7 @@
     }
    ],
    "source": [
-    "import qiskit.tools.jupyter\n",
+    "import tutorial_magics\n",
     "\n",
     "%qiskit_version_table\n",
     "%qiskit_copyright"

--- a/docs/tutorials/08_cvar_optimization.ipynb
+++ b/docs/tutorials/08_cvar_optimization.ipynb
@@ -339,7 +339,7 @@
     }
    ],
    "source": [
-    "import qiskit.tools.jupyter\n",
+    "import tutorial_magics\n",
     "\n",
     "%qiskit_version_table\n",
     "%qiskit_copyright"

--- a/docs/tutorials/09_application_classes.ipynb
+++ b/docs/tutorials/09_application_classes.ipynb
@@ -524,7 +524,7 @@
     }
    ],
    "source": [
-    "import qiskit.tools.jupyter\n",
+    "import tutorial_magics\n",
     "\n",
     "%qiskit_version_table\n",
     "%qiskit_copyright"

--- a/docs/tutorials/10_warm_start_qaoa.ipynb
+++ b/docs/tutorials/10_warm_start_qaoa.ipynb
@@ -46,7 +46,7 @@
     "# Qiskit imports\n",
     "from qiskit_algorithms import QAOA, NumPyMinimumEigensolver\n",
     "from qiskit_algorithms.optimizers import COBYLA\n",
-    "from qiskit_algorithms.utils.algorithm_globals import algorithm_globals\n",
+    "from qiskit_algorithms.utils import algorithm_globals\n",
     "from qiskit.primitives import Sampler\n",
     "from qiskit_optimization.algorithms import MinimumEigenOptimizer, CplexOptimizer\n",
     "from qiskit_optimization import QuadraticProgram\n",
@@ -700,7 +700,7 @@
     }
    ],
    "source": [
-    "import qiskit.tools.jupyter\n",
+    "import tutorial_magics\n",
     "\n",
     "%qiskit_version_table\n",
     "%qiskit_copyright"
@@ -717,7 +717,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -731,7 +731,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/11_using_classical_optimization_solvers_and_models.ipynb
+++ b/docs/tutorials/11_using_classical_optimization_solvers_and_models.ipynb
@@ -556,7 +556,7 @@
     }
    ],
    "source": [
-    "import qiskit.tools.jupyter\n",
+    "import tutorial_magics\n",
     "\n",
     "%qiskit_version_table\n",
     "%qiskit_copyright"

--- a/docs/tutorials/12_quantum_random_access_optimizer.ipynb
+++ b/docs/tutorials/12_quantum_random_access_optimizer.ipynb
@@ -851,7 +851,7 @@
     }
    ],
    "source": [
-    "import qiskit.tools.jupyter\n",
+    "import tutorial_magics\n",
     "\n",
     "%qiskit_version_table\n",
     "%qiskit_copyright"

--- a/docs/tutorials/tutorial_magics.py
+++ b/docs/tutorials/tutorial_magics.py
@@ -1,0 +1,96 @@
+# This code is part of a Qiskit project
+#
+# (C) Copyright IBM 2017, 2024
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+# pylint: disable=unused-argument
+
+"""A module for version and copyright magics."""
+
+import datetime
+import platform
+import time
+from sys import modules
+
+from IPython import get_ipython
+from IPython.core.magic import line_magic, Magics, magics_class
+from IPython.display import HTML, display
+
+import qiskit
+
+
+@magics_class
+class Copyright(Magics):
+    """A class of status magic functions."""
+
+    @line_magic
+    def qiskit_copyright(self, line="", cell=None):
+        """A Jupyter magic function return qiskit copyright"""
+        now = datetime.datetime.now()
+
+        html = "<div style='width: 100%; background-color:#d5d9e0;"
+        html += "padding-left: 10px; padding-bottom: 10px; padding-right: 10px; padding-top: 5px'>"
+        html += "<h3>This code is a part of a Qiskit project</h3>"
+        html += "<p>&copy; Copyright IBM 2017, %s.</p>" % now.year
+        html += "<p>This code is licensed under the Apache License, Version 2.0. You may<br>"
+        html += "obtain a copy of this license in the LICENSE.txt file in the root directory<br> "
+        html += "of this source tree or at http://www.apache.org/licenses/LICENSE-2.0."
+
+        html += "<p>Any modifications or derivative works of this code must retain this<br>"
+        html += "copyright notice, and modified files need to carry a notice indicating<br>"
+        html += "that they have been altered from the originals.</p>"
+        html += "</div>"
+        return display(HTML(html))
+
+
+@magics_class
+class VersionTable(Magics):
+    """A class of status magic functions."""
+
+    @line_magic
+    def qiskit_version_table(self, line="", cell=None):
+        """
+        Print an HTML-formatted table with version numbers for Qiskit and its
+        dependencies. This should make it possible to reproduce the environment
+        and the calculation later on.
+        """
+        html = "<h3>Version Information</h3>"
+        html += "<table>"
+        html += "<tr><th>Software</th><th>Version</th></tr>"
+
+        packages = {"qiskit": qiskit.__version__}
+        qiskit_modules = {module.split(".")[0] for module in modules.keys() if "qiskit" in module}
+
+        for qiskit_module in qiskit_modules:
+            packages[qiskit_module] = getattr(modules[qiskit_module], "__version__", None)
+
+        for name, version in packages.items():
+            if version:
+                html += f"<tr><td><code>{name}</code></td><td>{version}</td></tr>"
+
+        html += "<tr><th colspan='2'>System information</th></tr>"
+
+        sys_info = [
+            ("Python version", platform.python_version()),
+            ("OS", "%s" % platform.system()),
+        ]
+
+        for name, version in sys_info:
+            html += f"<tr><td>{name}</td><td>{version}</td></tr>"
+
+        html += "<tr><td colspan='2'>%s</td></tr>" % time.strftime("%a %b %d %H:%M:%S %Y %Z")
+        html += "</table>"
+
+        return display(HTML(html))
+
+
+_IP = get_ipython()
+if _IP is not None:
+    _IP.register_magics(VersionTable)
+    _IP.register_magics(Copyright)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Qiskit 1,0 removed the deprecated qiskit.tools which included some .jupyter from which the magics that did the version and copyright were imported. This PR adds a local file in the tutorials folder that contains just these magics and changes the import to use this.

Similar fix to qiskit-community/qiskit-algorithms#156

I removed an import from qiskit.tools which is now gone - the import did not seem to be used anymore

I also tweaked one of the imports so it does not import direct from the module but just from qiskit_algorithms.utils

### Details and comments

I do not expect this to pass until the other failures are sorted. A new release of Qiskit Algorithms is required to work with Qiskit 1.0, but at least its ready.

