### PR TITLE
Pin numpy<2 and scipy<1.14

### DIFF
--- a/qiskit_optimization/__init__.py
+++ b/qiskit_optimization/__init__.py
@@ -69,7 +69,7 @@ are that it cannot proceed to completion.
    :toctree: ../stubs/
    :nosignatures:
 
-    ~qiskit_optimization.infinity.INFINITY
+    ~infinity.INFINITY
 
 Submodules
 ==========

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 qiskit>=0.44
 qiskit-algorithms>=0.2.0
 scipy>=1.9.0
-numpy>=1.17
+numpy>=1.17,<2
 docplex>=2.21.207,!=2.24.231
 setuptools>=40.1.0
 networkx>=2.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 qiskit>=0.44
 qiskit-algorithms>=0.2.0
-scipy>=1.9.0
+scipy>=1.9.0,<1.14
 numpy>=1.17,<2
 docplex>=2.21.207,!=2.24.231
 setuptools>=40.1.0


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Docplex does not support Numpy version 2 and qiskit-algorithms does not support Scipy 1.14.
So, this PR pin the numpy and scipy versions.

This also fixes a warning of sphinx related to `INFINITY`.

### Details and comments


