### PR TITLE
Fix incorrect decoding of decision variables by ``MagicRounding``

### DIFF
--- a/qiskit_optimization/algorithms/qrao/magic_rounding.py
+++ b/qiskit_optimization/algorithms/qrao/magic_rounding.py
@@ -232,7 +232,8 @@ class MagicRounding(RoundingScheme):
         """
         output_bits = []
         # iterate in order over decision variables
-        for q, op in var2op.values():
+        for var in sorted(var2op.keys()):
+            q, op = var2op[var]
             # get the decoding outcome index for the variable
             # corresponding to this Pauli op.
             op_index = self._OP_INDICES[vars_per_qubit][str(op.paulis[0])]

--- a/qiskit_optimization/algorithms/qrao/magic_rounding.py
+++ b/qiskit_optimization/algorithms/qrao/magic_rounding.py
@@ -232,8 +232,7 @@ class MagicRounding(RoundingScheme):
         """
         output_bits = []
         # iterate in order over decision variables
-        for var in sorted(var2op.keys()):
-            q, op = var2op[var]
+        for _, (q, op) in sorted(var2op.items()):
             # get the decoding outcome index for the variable
             # corresponding to this Pauli op.
             op_index = self._OP_INDICES[vars_per_qubit][str(op.paulis[0])]

--- a/releasenotes/notes/fix-qrao-d0402da6a5c40121.yaml
+++ b/releasenotes/notes/fix-qrao-d0402da6a5c40121.yaml
@@ -1,5 +1,4 @@
 ---
 fixes:
   - |
-    Fixed incorrect iteration order ``var2op.values()``
-    in :class:`~qiskit_optimization.algorithms.qrao.MagicRounding`.
+    Fixed a bug of :meth:`.MagicRounding.round` that may return a wrong decision variable order.

--- a/releasenotes/notes/fix-qrao-d0402da6a5c40121.yaml
+++ b/releasenotes/notes/fix-qrao-d0402da6a5c40121.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed incorrect iteration order ``var2op.values()``
+    in :class:`~qiskit_optimization.algorithms.qrao.MagicRounding`.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fix ``MagicRounding`` so that the decision variables can be decoded correctly.
Fix #626. 

### Details and comments
The iteration order of ``var2op`` in the method, ``_unpack_measurement_outcome`` in :class:`~qiskit_optimization.algorithms.qrao.MagicRounding` has been modified so that it can correctly run in the order of the decision variables.


✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.