### PR TITLE
Unpin numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 qiskit>=0.44
 qiskit-algorithms>=0.2.0
 scipy>=1.9.0,<1.14
-numpy>=1.17,<2
+numpy>=1.17
 docplex>=2.21.207,!=2.24.231
 setuptools>=40.1.0
 networkx>=2.6.3

--- a/test/algorithms/qrao/test_quantum_random_access_optimizer.py
+++ b/test/algorithms/qrao/test_quantum_random_access_optimizer.py
@@ -70,7 +70,7 @@ class TestQuantumRandomAccessOptimizer(QiskitOptimizationTestCase):
         """Test QuantumRandomAccessOptimizer with VQE."""
         vqe = VQE(
             ansatz=self.ansatz,
-            optimizer=COBYLA(),
+            optimizer=COBYLA(tol=1e-6),
             estimator=Estimator(),
         )
         qrao = QuantumRandomAccessOptimizer(min_eigen_solver=vqe)
@@ -78,9 +78,9 @@ class TestQuantumRandomAccessOptimizer(QiskitOptimizationTestCase):
         self.assertIsInstance(relaxed_results, VQEResult)
         self.assertAlmostEqual(relaxed_results.eigenvalue, -2.73861, delta=1e-4)
         self.assertEqual(len(relaxed_results.aux_operators_evaluated), 3)
-        self.assertAlmostEqual(relaxed_results.aux_operators_evaluated[0][0], 0.31632, delta=1e-4)
-        self.assertAlmostEqual(relaxed_results.aux_operators_evaluated[1][0], 0, delta=1e-4)
-        self.assertAlmostEqual(relaxed_results.aux_operators_evaluated[2][0], 0.94865, delta=1e-4)
+        self.assertAlmostEqual(relaxed_results.aux_operators_evaluated[0][0].item(), 0.31632, delta=1e-4)
+        self.assertAlmostEqual(relaxed_results.aux_operators_evaluated[1][0].item(), 0, delta=1e-4)
+        self.assertAlmostEqual(relaxed_results.aux_operators_evaluated[2][0].item(), 0.94865, delta=1e-4)
         self.assertIsInstance(rounding_context, RoundingContext)
         self.assertEqual(rounding_context.circuit.num_qubits, self.ansatz.num_qubits)
         self.assertEqual(rounding_context.encoding, self.encoding)

--- a/test/algorithms/qrao/test_quantum_random_access_optimizer.py
+++ b/test/algorithms/qrao/test_quantum_random_access_optimizer.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023.
+# (C) Copyright IBM 2023, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -78,9 +78,13 @@ class TestQuantumRandomAccessOptimizer(QiskitOptimizationTestCase):
         self.assertIsInstance(relaxed_results, VQEResult)
         self.assertAlmostEqual(relaxed_results.eigenvalue, -2.73861, delta=1e-4)
         self.assertEqual(len(relaxed_results.aux_operators_evaluated), 3)
-        self.assertAlmostEqual(relaxed_results.aux_operators_evaluated[0][0].item(), 0.31632, delta=1e-4)
+        self.assertAlmostEqual(
+            relaxed_results.aux_operators_evaluated[0][0].item(), 0.31632, delta=1e-4
+        )
         self.assertAlmostEqual(relaxed_results.aux_operators_evaluated[1][0].item(), 0, delta=1e-4)
-        self.assertAlmostEqual(relaxed_results.aux_operators_evaluated[2][0].item(), 0.94865, delta=1e-4)
+        self.assertAlmostEqual(
+            relaxed_results.aux_operators_evaluated[2][0].item(), 0.94865, delta=1e-4
+        )
         self.assertIsInstance(rounding_context, RoundingContext)
         self.assertEqual(rounding_context.circuit.num_qubits, self.ansatz.num_qubits)
         self.assertEqual(rounding_context.encoding, self.encoding)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

docplex 2.28.240 was released on Aug 2 with numpy 2 support. So, I unpin the numpy version
https://pypi.org/project/docplex/2.28.240/#history

requires #630 to pass CI 

### Details and comments


