### PR TITLE
Pin pip for "pip check"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,10 @@ jobs:
           pip install pyenchant
           echo "earliest_version: 0.1.0" >> releasenotes/config.yaml
         shell: bash
-      - run:  pip check
+      - name: Run pip check
+        run: |
+          pip install "pip<24.2"
+          pip check
         if: ${{ !cancelled() }}
         shell: bash
       - name: Copyright Check


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`pip check` of CI fails since a couple of days ago.
```
gurobipy 11.0.3 is not supported on this platform
```

I found an issue of pip https://github.com/pypa/pip/issues/12884 is likely to be related to the failure. I try to pin pip only for `pip check`.


### Details and comments


