### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,5 +3,5 @@
 # least one codeowner. However, all Qiskit team members can (and should!) review the PRs.
 
 # Global rule, unless specialized by a later one
-* @stefan-woerner @woodsp-ibm @t-imamichi @dthuerck @Sofranac-Boro
+* @stefan-woerner @woodsp-ibm @t-imamichi @TolisChal @thkleinert @Dniskk
 


### PR DESCRIPTION
### Summary
In order to simplify and speedup the review processes, Quantagonia contributors should be code owners.


### Details and comments
Removed former Quantagonia contributors and added current ones. 


