### PR TITLE
Pin numpy<2.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 qiskit>=0.44
 qiskit-algorithms>=0.2.0
 scipy>=1.9.0,<1.14
-numpy>=1.17
+numpy>=1.17,<2.2.0
 docplex>=2.21.207,!=2.24.231
 setuptools>=40.1.0
 networkx>=2.6.3


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

numpy 2.2.0 was released recently and it causes mypy errors as follows.
In order to merge existing PRs, I would like to pin numpy version first.
After we merge all existing PRs, we get back to these mypy errors.

I feel the error does not make sense because `tuple[int, int]` should be matched `tuple[int, ...]`.

```
qiskit_optimization/converters/linear_inequality_to_penalty.py:218: error: Incompatible types in assignment (expression has type "ndarray[tuple[int, ...], dtype[Any]]", variable has type "ndarray[tuple[int, int], dtype[Any]]")  [assignment]
qiskit_optimization/converters/linear_inequality_to_penalty.py:221: error: Incompatible types in assignment (expression has type "ndarray[tuple[int, ...], dtype[Any]]", variable has type "ndarray[tuple[int, int], dtype[Any]]")  [assignment]
qiskit_optimization/converters/linear_inequality_to_penalty.py:227: error: Incompatible types in assignment (expression has type "ndarray[tuple[int, ...], dtype[Any]]", variable has type "ndarray[tuple[int, int], dtype[Any]]")  [assignment]
qiskit_optimization/converters/linear_equality_to_penalty.py:144: error: Argument 1 to "extend" of "list" has incompatible type "str"; expected "Iterable[float]"  [arg-type]
qiskit_optimization/converters/linear_equality_to_penalty.py:144: note: Following member(s) of "str" have conflicts:
qiskit_optimization/converters/linear_equality_to_penalty.py:144: note:     Expected:
qiskit_optimization/converters/linear_equality_to_penalty.py:144: note:         def __iter__(self) -> Iterator[float]
qiskit_optimization/converters/linear_equality_to_penalty.py:144: note:     Got:
qiskit_optimization/converters/linear_equality_to_penalty.py:144: note:         def __iter__(self) -> Iterator[str]
qiskit_optimization/algorithms/admm_optimizer.py:860: error: Incompatible types in assignment (expression has type "ndarray[tuple[int, ...], Any]", variable has type "ndarray[tuple[int], dtype[float64]]")  [assignment]
qiskit_optimization/algorithms/admm_optimizer.py:861: error: Incompatible types in assignment (expression has type "ndarray[tuple[int, ...], Any]", variable has type "ndarray[tuple[int], dtype[float64]]")  [assignment]
qiskit_optimization/algorithms/admm_optimizer.py:862: error: Incompatible types in assignment (expression has type "ndarray[tuple[int, ...], Any]", variable has type "ndarray[tuple[int], dtype[float64]]")  [assignment]
Found 7 errors in 3 files (checked 126 source files)
```


### Details and comments


