### PR TITLE
Update intersphinx mapping and other URLs pointing to IQP Classic

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2024.
+# (C) Copyright IBM 2021, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -182,7 +182,7 @@ intersphinx_mapping = {
     "scipy": ("https://docs.scipy.org/doc/scipy", None),
     "networkx": ("https://networkx.org/documentation/stable", None),
     "docplex.mp": ("https://ibmdecisionoptimization.github.io/docplex-doc/mp", None),
-    "qiskit": ("https://docs.quantum.ibm.com/api/qiskit", None),
+    "qiskit": ("https://quantum.cloud.ibm.com/docs/api/qiskit", None),
     "qiskit_algorithms": ("https://qiskit-community.github.io/qiskit-algorithms", None),
 }
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -8,7 +8,7 @@ Installation
 ============
 
 Qiskit Optimization depends on Qiskit, which has its own
-`installation instructions <https://docs.quantum.ibm.com/start/install>`__ detailing the
+`installation instructions <https://quantum.cloud.ibm.com/docs/guides/install-qiskit>`__ detailing the
 installation options for Qiskit and its supported environments/platforms. You should refer to
 that first. Then the information here can be followed which focuses on the additional installation
 specific to Qiskit Optimization.
@@ -21,7 +21,7 @@ See :ref:`optional_installs` for more information.
 
     .. tab-item:: Start locally
 
-        The simplest way to get started is to follow the `Qiskit installation instructions <https://docs.quantum.ibm.com/start/install>`__
+        The simplest way to get started is to follow the `Qiskit installation instructions <https://quantum.cloud.ibm.com/docs/guides/install-qiskit>`__
 
         In your virtual environment where you installed Qiskit, also install ``qiskit-optimization``:
 
@@ -44,7 +44,7 @@ See :ref:`optional_installs` for more information.
 
        Since Qiskit Optimization depends on Qiskit, and its latest changes may require new or changed
        features of Qiskit, you should first follow Qiskit's `"Install from source"` instructions
-       `here <https://docs.quantum.ibm.com/start/install-qiskit-source>`__
+       `here <https://quantum.cloud.ibm.com/docs/start/install-qiskit-source>`__
 
        .. raw:: html
 

--- a/docs/migration/01_migration_guide_to_v0.5.rst
+++ b/docs/migration/01_migration_guide_to_v0.5.rst
@@ -9,7 +9,7 @@ Overview
 
 Qiskit Terra v0.22 introduces new algorithm implementations that
 leverage `Qiskit
-Primitives <https://docs.quantum.ibm.com/api/qiskit/primitives>`__
+Primitives <https://quantum.cloud.ibm.com/docs/api/qiskit/primitives>`__
 (Estimator and Sampler). The former algorithm implementations that
 leverage opflow will be deprecated in the future release.
 
@@ -19,7 +19,7 @@ of Qiskit Terra v0.22 until the former algorithms are deprecated.
 It is not the intention to provide detailed explanations of the
 primitives in this migration guide. We suggest that you read the
 `corresponding
-resources <https://docs.quantum.ibm.com/api/qiskit/primitives>`__
+resources <https://quantum.cloud.ibm.com/docs/api/qiskit/primitives>`__
 of the Qiskit Terra documentation instead.
 
 We use ``qiskit.primitives.Sampler`` in this guide as an example of

--- a/releasenotes/notes/0.5/add-primitives-support-31af39549b5e66e3.yaml
+++ b/releasenotes/notes/0.5/add-primitives-support-31af39549b5e66e3.yaml
@@ -1,7 +1,7 @@
 ---
 prelude: >
     Qiskit Optimization 0.5 supports the new algorithms introduced in Qiskit Terra 0.22
-    which in turn rely on the `Qiskit Primitives <https://docs.quantum.ibm.com/api/qiskit/primitives>`_.
+    which in turn rely on the `Qiskit Primitives <https://quantum.cloud.ibm.com/docs/api/qiskit/primitives>`_.
     Qiskit Optimization 0.5 still supports the former algorithms based on :class:`qiskit.utils.QuantumInstance`,
     but they will be deprecated and then removed, along with the support here, in future releases.
 


### PR DESCRIPTION
The documentation source of truth is moving to https://quantum.cloud.ibm.com/.