### PR TITLE
Add Python 3.14 support and drop Python 3.9 support

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -40,7 +40,7 @@ runs:
         if [ "${{ inputs.event-name }}" == "schedule" ] || [ "${{ inputs.run-slow }}" == "true" ]; then
           export QISKIT_TESTS="run_slow"
         fi
-        if [ "${{ inputs.os }}" == "ubuntu-latest" ] && [ "${{ inputs.python-version }}" == "3.9" ]; then
+        if [ "${{ inputs.os }}" == "ubuntu-latest" ] && [ "${{ inputs.python-version }}" == "3.10" ]; then
           export PYTHON="coverage3 run --source qiskit_optimization --parallel-mode"
         fi
         stestr --test-path test run 2> >(tee /dev/stderr out.txt > /dev/null)

--- a/.github/workflows/deploy-code.yml
+++ b/.github/workflows/deploy-code.yml
@@ -25,7 +25,7 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: ['3.10']
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: ['3.10']
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: ['3.10']
     steps:
       - name: Print Concurrency Group
         env:
@@ -119,16 +119,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9, '3.10', 3.11, 3.12, 3.13]
+        python-version: ['3.10', 3.11, 3.12, 3.13, 3.14]
         include:
           - os: macos-latest
-            python-version: 3.9
+            python-version: '3.10'
           - os: macos-latest
-            python-version: 3.11
+            python-version: 3.14
           - os: windows-latest
-            python-version: 3.9
+            python-version: '3.10'
           - os: windows-latest
-            python-version: 3.12
+            python-version: 3.14
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -197,7 +197,7 @@ jobs:
           fi
           coverage3 combine
           mv .coverage ./ci-artifact-data/opt.dat
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == 3.9 }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10' }}
         shell: bash
       - uses: actions/upload-artifact@v7
         with:
@@ -225,7 +225,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9, 3.12]
+        python-version: ['3.10', 3.14]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -290,30 +290,26 @@ jobs:
           cd docs/_build/html
           mkdir artifacts
           tar -zcvf artifacts/tutorials.tar.gz --exclude=./artifacts .
-        if: ${{ matrix.python-version == 3.9 && !startsWith(github.ref, 'refs/heads/stable') && !startsWith(github.base_ref, 'stable/') }}
+        if: ${{ matrix.python-version == '3.10' && !startsWith(github.ref, 'refs/heads/stable') && !startsWith(github.base_ref, 'stable/') }}
         shell: bash
       - name: Run upload stable tutorials
         uses: actions/upload-artifact@v7
         with:
           name: tutorials-stable${{ matrix.python-version }}
           path: docs/_build/html/artifacts/tutorials.tar.gz
-        if: ${{ matrix.python-version == 3.9 && !startsWith(github.ref, 'refs/heads/stable') && !startsWith(github.base_ref, 'stable/') }}
+        if: ${{ matrix.python-version == '3.10' && !startsWith(github.ref, 'refs/heads/stable') && !startsWith(github.base_ref, 'stable/') }}
   Deprecation_Messages_and_Coverage:
     if: github.repository_owner == 'qiskit-community'
     needs: [Checks, Optimization, Tutorials]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: ['3.10']
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: actions/download-artifact@v8
-        with:
-          name: ubuntu-latest-3.9
-          path: /tmp/o39
       - uses: actions/download-artifact@v8
         with:
           name: ubuntu-latest-3.10
@@ -332,29 +328,33 @@ jobs:
           path: /tmp/o313
       - uses: actions/download-artifact@v8
         with:
-          name: macos-latest-3.9
-          path: /tmp/m39
+          name: ubuntu-latest-3.14
+          path: /tmp/o314
       - uses: actions/download-artifact@v8
         with:
-          name: macos-latest-3.11
-          path: /tmp/m311
+          name: macos-latest-3.10
+          path: /tmp/m310
       - uses: actions/download-artifact@v8
         with:
-          name: windows-latest-3.9
-          path: /tmp/w39
+          name: macos-latest-3.14
+          path: /tmp/m314
       - uses: actions/download-artifact@v8
         with:
-          name: windows-latest-3.12
-          path: /tmp/w312
+          name: windows-latest-3.10
+          path: /tmp/w310
+      - uses: actions/download-artifact@v8
+        with:
+          name: windows-latest-3.14
+          path: /tmp/w314
       - name: Install Dependencies
         run: pip install -U coverage coveralls diff-cover
         shell: bash
       - name: Combined Deprecation Messages
         run: |
-          sort -f -u /tmp/o39/opt.dep /tmp/o310/opt.dep /tmp/o311/opt.dep /tmp/o312/opt.dep /tmp/o313/opt.dep /tmp/m39/opt.dep /tmp/m311/opt.dep /tmp/w39/opt.dep /tmp/w312/opt.dep || true
+          sort -f -u /tmp/o310/opt.dep /tmp/o311/opt.dep /tmp/o312/opt.dep /tmp/o313/opt.dep /tmp/o314/opt.dep /tmp/m310/opt.dep /tmp/m314/opt.dep /tmp/w310/opt.dep /tmp/w314/opt.dep || true
         shell: bash
       - name: Coverage combine
-        run: coverage3 combine /tmp/o39/opt.dat
+        run: coverage3 combine /tmp/o310/opt.dat
         shell: bash
       - name: Upload to Coveralls
         run: coveralls

--- a/releasenotes/notes/add-python314-support-5e42380fb3c8117d.yaml
+++ b/releasenotes/notes/add-python314-support-5e42380fb3c8117d.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Added support for using Qiskit Optimization with Python 3.14.
+upgrade:
+  - |
+    Support for running with Python 3.9 has been removed.
+    To run Qiskit Optimization you need a minimum Python version of 3.10.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 qiskit>=1.1,<3
 scipy>=1.9.0
 numpy>=1.17
-docplex>=2.21.207,!=2.24.231
+docplex>=2.21.207,!=2.24.231,!=2.32.257
 setuptools>=40.1.0
 networkx>=2.6.3

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2025.
+# (C) Copyright IBM 2021, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -61,22 +61,20 @@ setuptools.setup(
         "Operating System :: MacOS",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Topic :: Scientific/Engineering",
     ],
     keywords="qiskit sdk quantum optimization",
     packages=setuptools.find_packages(include=["qiskit_optimization", "qiskit_optimization.*"]),
     install_requires=REQUIREMENTS,
     include_package_data=True,
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     extras_require={
-        "cplex": [
-            "cplex; (python_version < '3.13' and platform_system != 'Darwin') or (python_version < '3.12' and platform_system == 'Darwin')"
-        ],
+        "cplex": ["cplex; python_version < '3.15'"],
         "cvx": ["cvxpy"],
         "matplotlib": ["matplotlib"],
         "gurobi": ["gurobipy"],


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Python 3.9 EOL on Oct 31, 2025.
https://devguide.python.org/versions/

Add the constraint reported by #716 

cplex started to support Python 3.13 and 3.14 since 22.1.2.1.
https://pypi.org/project/cplex/22.1.2.1/#files

### Details and comments

Closes #638 

